### PR TITLE
local.conf: let bitbake determine the optimal parallelism

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -11,9 +11,6 @@ BB_DISKMON_DIRS = "\
     ABORT,${SSTATE_DIR},100M,1K" 
 CONF_VERSION = "1"
 
-BB_NUMBER_THREADS = "${@oe.utils.cpu_count() * 2}"
-PARALLEL_MAKE = "-j ${@oe.utils.cpu_count() * 2}"
-
 DL_DIR ?= "${BSPDIR}/downloads/"
 ACCEPT_FSL_EULA = "1"
 


### PR DESCRIPTION
According to Yocto manual the ability to choose reasonable parallelism has
been heavily improved. Instead of defining own values, let bitbake determine.

Signed-off-by: Jens Rehsack sno@netbsd.org
