### PR TITLE
local.conf: add line for easy enabling build info beside release builds

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -19,6 +19,7 @@ include include/kodi_14.inc
 
 FILESYSTEM_PERMS_TABLES = "files/rdm-perms.txt"
 
+#INHERIT += "image-buildinfo"
 INHERIT += "buildhistory"
 BUILDHISTORY_COMMIT = "0"
 BUILDHISTORY_FEATURES = "image"


### PR DESCRIPTION
Add buildinfo line to allows developer builds are clear about the
delivered content.

Signed-off-by: Jens Rehsack sno@netbsd.org
